### PR TITLE
correctly detect all external dependencies

### DIFF
--- a/plops/lib/templates/vite.config.ts
+++ b/plops/lib/templates/vite.config.ts
@@ -4,10 +4,13 @@ import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import packageJson from './package.json';
 
-const external = [
+const dependencies = [
   ...Object.keys(packageJson.dependencies ?? {}),
   ...Object.keys(packageJson.peerDependencies ?? {}),
 ];
+
+let external = (source: string) =>
+  dependencies.some((dep) => source === dep || source.startsWith(dep + '/'));
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/plops/react-lib/templates/vite.config.ts
+++ b/plops/react-lib/templates/vite.config.ts
@@ -5,10 +5,13 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import packageJson from './package.json';
 
-const external = [
+const dependencies = [
   ...Object.keys(packageJson.dependencies ?? {}),
   ...Object.keys(packageJson.peerDependencies ?? {}),
 ];
+
+let external = (source: string) =>
+  dependencies.some((dep) => source === dep || source.startsWith(dep + '/'));
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
# Problem

Previously, the Vite configuration only marked root-level package imports (e.g., `react`) as external dependencies, while subpath imports (e.g., `react/jsx-runtime`) were incorrectly bundled. This led to larger bundle sizes and potential duplication of dependencies.

# Impact

- All dependency imports (both root-level and subpaths) are now correctly treated as external
- Results in smaller bundle sizes by preventing bundling of dependency code
- Maintains proper peer dependency behavior for library consumers